### PR TITLE
Support Dark Mode by invalidating layers when traitCollection changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.xcbkptlist
+.build

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/CPAnimatedPlayingIndicatorView/Base.lproj/Main.storyboard
+++ b/CPAnimatedPlayingIndicatorView/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -21,7 +19,7 @@
                             <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1yF-F6-myx" customClass="CPAnimatedPlayingIndicatorView">
                                 <rect key="frame" x="67" y="119" width="240" height="128"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" white="0.94999999999999996" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="barCount">
                                         <integer key="value" value="5"/>
@@ -34,6 +32,9 @@
                                     </userDefinedRuntimeAttribute>
                                     <userDefinedRuntimeAttribute type="number" keyPath="animationSpeed">
                                         <real key="value" value="10"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="color">
+                                        <color key="value" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
@@ -116,7 +117,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <connections>

--- a/Classes/CPAnimatedPlayingIndicatorView.m
+++ b/Classes/CPAnimatedPlayingIndicatorView.m
@@ -31,7 +31,6 @@ static inline CGPathRef fullAmplitudeBarPath(CGRect bounds, float barSpacing, fl
 }
 
 @implementation CPAnimatedPlayingIndicatorView{
-    CGColorRef colorRef;
     BOOL didAwake;
     int animationStartCounter;
     BOOL animating;
@@ -57,6 +56,7 @@ static inline CGPathRef fullAmplitudeBarPath(CGRect bounds, float barSpacing, fl
 -(void)createLayers{
     CGRect bounds = self.bounds;
     float barWidth = ((bounds.size.width - (_barSpacing * (_barCount - 1))) / _barCount);
+    CGColorRef colorRef = self.color.CGColor;
     for (int i = 0; i < _barCount; i++) {
         CGPathRef path = zeroAmplitudeBarPath(bounds, _barSpacing, barWidth, _cornerRadius, i, _barCount);
         CAShapeLayer *shapeLayer = [[CAShapeLayer alloc] init];
@@ -72,6 +72,11 @@ static inline CGPathRef fullAmplitudeBarPath(CGRect bounds, float barSpacing, fl
     [self performLayout];
 }
 
+-(void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+    [super traitCollectionDidChange:previousTraitCollection];
+    [self invalidateLayers];
+}
+
 -(void)setBarCount:(int)barCount{
     _barCount = barCount;
     [self setNeedsDisplay];
@@ -79,7 +84,6 @@ static inline CGPathRef fullAmplitudeBarPath(CGRect bounds, float barSpacing, fl
 
 -(void)setColor:(UIColor *)color{
     _color = color;
-    colorRef = color.CGColor;
     [self setNeedsDisplay];
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+  name: "CPAnimatedPlayingIndicatorView",
+  platforms: [ .iOS(.v10)],
+  products: [
+    // Products define the executables and libraries produced by a package, and make them visible to other packages.
+    .library(
+      name: "CPAnimatedPlayingIndicatorView",
+      targets: ["CPAnimatedPlayingIndicatorView"]),
+  ],
+  dependencies: [],
+  targets: [
+    .target(
+      name: "CPAnimatedPlayingIndicatorView",
+      path: "Classes",
+      publicHeadersPath: ""
+      )
+  ]
+)


### PR DESCRIPTION
I'm using this in the new Spkr. app that launched this week:
https://apps.apple.com/us/app/spkr/id1459154335

We are aggressively supporting Dark Mode, and need this view to work with dynamic colors. Simple change: when traitCollectionDidChange is called on the view, it should redraw.

Thanks!
Alan Cannistraro